### PR TITLE
[fixed] ConfigMap path does not exists

### DIFF
--- a/example/galera.yaml
+++ b/example/galera.yaml
@@ -22,6 +22,27 @@ kind: ConfigMap
 metadata:
   name: mysql-config-vol
 data:
+  galera.cnf: |
+    [galera]
+    user = mysql
+    bind-address = 0.0.0.0
+
+    default_storage_engine = InnoDB
+    binlog_format = ROW
+    innodb_autoinc_lock_mode = 2
+    innodb_flush_log_at_trx_commit = 0
+    query_cache_size = 0
+    query_cache_type = 0
+
+    # MariaDB Galera settings
+    wsrep_on=ON
+    wsrep_provider=/usr/lib/galera/libgalera_smm.so
+    wsrep_sst_method=rsync
+
+    # Cluster settings (automatically updated)
+    wsrep_cluster_address=gcomm://
+    wsrep_cluster_name=galera
+    wsrep_node_address=127.0.0.1
   mariadb.cnf: |
     [client]
     default-character-set = utf8


### PR DESCRIPTION
This fix was provided by christophlehmann in https://github.com/ausov/k8s-mariadb-cluster/issues/1