### PR TITLE
change example to support k8s 1.10

### DIFF
--- a/example/galera.yaml
+++ b/example/galera.yaml
@@ -64,6 +64,15 @@ spec:
       labels:
         app: mysql
     spec:
+      initContainers:
+      - name: copy-mariadb-config
+        image: busybox
+        command: ['sh', '-c', 'cp /configmap/* /etc/mysql/conf.d']
+        volumeMounts:
+        - name: configmap
+          mountPath: /configmap
+        - name: config
+          mountPath: /etc/mysql/conf.d
       containers:
       - name: mysql
         image: ausov/k8s-mariadb-cluster
@@ -99,6 +108,8 @@ spec:
           mountPath: /var/lib/mysql
       volumes:
       - name: config
+        emptyDir: {}
+      - name: configmap
         configMap:
           name: mysql-config-vol
           items:


### PR DESCRIPTION
As of 1.10 configmaps are read-only by default (can be turned back to writeable however using `ReadOnlyAPIDataVolumes`, but this is not recommended). As of 1.11 there will be no option: they'll be just read-only. This trick works around this issue.
P.S. "Stolen" from here: https://github.com/Eneco/charts/commit/bbb54eeffa74967b0b0ba1c72d25df87cf505992